### PR TITLE
Add functional bearer token authorization to the swagger

### DIFF
--- a/Source/Server/TeamTasker.Server.API/Program.cs
+++ b/Source/Server/TeamTasker.Server.API/Program.cs
@@ -17,6 +17,7 @@ using FluentValidation;
 using TeamTasker.Server.Application.Dtos.Users;
 using TeamTasker.Server.Application.Dtos.Validators;
 using FluentValidation.AspNetCore;
+using Microsoft.OpenApi.Models;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -29,7 +30,37 @@ builder.Services.AddFluentValidationAutoValidation().AddFluentValidationClientsi
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddAutoMapper(AppDomain.CurrentDomain.GetAssemblies());
 builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+
+// Adds Simple Bearer Token authorization to the swagger UI
+
+builder.Services.AddSwaggerGen(opt =>
+{
+    opt.SwaggerDoc("v1", new OpenApiInfo { Title = "MyAPI", Version = "v1" });
+    opt.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+    {
+        In = ParameterLocation.Header,
+        Description = "Please enter token",
+        Name = "Authorization",
+        Type = SecuritySchemeType.Http,
+        BearerFormat = "JWT",
+        Scheme = "bearer"
+    });
+
+    opt.AddSecurityRequirement(new OpenApiSecurityRequirement
+    {
+        {
+            new OpenApiSecurityScheme
+            {
+                Reference = new OpenApiReference
+                {
+                    Type=ReferenceType.SecurityScheme,
+                    Id="Bearer"
+                }
+            },
+            new string[]{}
+        }
+    });
+});
 
 builder.Services.AddCors(options =>
 {


### PR DESCRIPTION
This PR expands swagger functionality with authorization check - making in compatible with all authorization solutions on the backend server.