### PR TITLE
Change key of the issues from DB id to project related id

### DIFF
--- a/Source/Client/TeamTasker.Client.GUI/src/components/Modules/Board/IssueCard.tsx
+++ b/Source/Client/TeamTasker.Client.GUI/src/components/Modules/Board/IssueCard.tsx
@@ -27,7 +27,7 @@ export default function IssueCard({ReadIssueDto, projectId}: {ReadIssueDto: Read
                     <Grid container>
                         <Grid item xs={2}>
                             <Typography fontSize={15} color="gray" sx={{mt: "0.2rem", ml: "0.2rem"}}>
-                                #{ReadIssueDto.id}
+                                #{ReadIssueDto.projectIssueId}
                             </Typography>
                         </Grid>
                         <Grid item xs={10}>

--- a/Source/Client/TeamTasker.Client.GUI/src/components/Modules/IssuesList/PreviewIssuesTable.tsx
+++ b/Source/Client/TeamTasker.Client.GUI/src/components/Modules/IssuesList/PreviewIssuesTable.tsx
@@ -198,7 +198,7 @@ export default function PreviewIssuesTable({projectId, reloadCondition}: {projec
       <TableHead>
           <TableRow>
             <TableCell>ID</TableCell>
-            <TableCell align="left">Topic</TableCell>
+            <TableCell align="left">Description</TableCell>
             <TableCell align="left">Status</TableCell>
             <TableCell align="left">Assigned to</TableCell>
             <TableCell align="right">Priority</TableCell>
@@ -213,9 +213,9 @@ export default function PreviewIssuesTable({projectId, reloadCondition}: {projec
             IssuesListFilter(issue, currentUserEmail, projectEmployees)
 
             ?
-            <TableRow key={issue.id}>
+            <TableRow key={issue.projectIssueId}>
             <TableCell component="th" scope="row">
-              {issue.id}
+              {issue.projectIssueId}
             </TableCell>
             <TableCell component="th" scope="row">
               {issue.name}

--- a/Source/Client/TeamTasker.Client.GUI/src/components/Types/ReadIssuesDto.ts
+++ b/Source/Client/TeamTasker.Client.GUI/src/components/Types/ReadIssuesDto.ts
@@ -1,5 +1,6 @@
 export type ReadIssueDto = {
     id: number,
+    projectIssueId: number,
     name: string,
     description: string,
     startDate: string,


### PR DESCRIPTION
This PR fixes a known issue, that issues on the client side are shown with their database id, instead of project id. This led to invalid numeration in multiple projects.